### PR TITLE
Update Towny support.

### DIFF
--- a/Hook_Towny/build.gradle
+++ b/Hook_Towny/build.gradle
@@ -1,7 +1,11 @@
 group 'Hook_Towny'
 
+repositories {
+    maven { url 'https://repo.glaremasters.me/repository/towny/' }
+}
+
 dependencies {
-    compileOnly 'com.palmergames:Towny:latest'
+    compileOnly 'com.palmergames.bukkit.towny:towny:0.98.0.0'
     compileOnly "org.spigotmc:v1_8_R3-Taco:latest"
     compileOnly parent
 }

--- a/Hook_Towny/src/main/java/com/bgsoftware/wildinspect/hooks/ClaimsProvider_Towny.java
+++ b/Hook_Towny/src/main/java/com/bgsoftware/wildinspect/hooks/ClaimsProvider_Towny.java
@@ -24,7 +24,7 @@ public final class ClaimsProvider_Towny implements ClaimsProvider {
     @Override
     public boolean hasRole(Player player, Location location, String... roles) {
         try {
-            Resident resident = TownyAPI.getInstance().getDataSource().getResident(player.getName());
+            Resident resident = TownyAPI.getInstance().getResident(player.getUniqueId());
             return Arrays.stream(roles).anyMatch(resident::hasTownRank) || (Arrays.asList(roles).contains("MAYOR") && resident.isMayor());
         } catch (Exception ignored) {
         }
@@ -36,7 +36,7 @@ public final class ClaimsProvider_Towny implements ClaimsProvider {
     public boolean hasRegionAccess(Player player, Location location) {
         try {
             TownBlock block = WorldCoord.parseWorldCoord(location).getTownBlock();
-            Resident resident = TownyAPI.getInstance().getDataSource().getResident(player.getName());
+            Resident resident = TownyAPI.getInstance().getResident(player.getUniqueId());
 
             return resident.hasTown() && resident.getTown().hasTownBlock(block);
         } catch (Exception ignored) {

--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ allprojects {
         maven { url 'https://repo.bg-software.com/repository/api/' }
         maven { url 'https://repo.bg-software.com/repository/common/' }
         maven { url 'https://repo.bg-software.com/repository/public-libs/' }
+        maven { url 'https://repo.glaremasters.me/repository/towny/' }
 
         String mavenUsername = System.getenv('mavenUsername') == null ? project.mavenUsername : System.getenv('mavenUsername');
         String mavenPassword = System.getenv('mavenPassword') == null ? project.mavenUsername : System.getenv('mavenPassword');
@@ -55,6 +56,8 @@ dependencies {
     compileOnly "org.spigotmc:v1_8_R3-Taco:latest"
     // CoreProtect
     compileOnly 'net.coreprotect:CoreProtect-6:latest'
+    // Towny
+    compileOnly 'com.palmergames.bukkit.towny:towny:0.98.0.0'
     // Plugin Hooks
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,6 @@ allprojects {
         maven { url 'https://repo.bg-software.com/repository/api/' }
         maven { url 'https://repo.bg-software.com/repository/common/' }
         maven { url 'https://repo.bg-software.com/repository/public-libs/' }
-        maven { url 'https://repo.glaremasters.me/repository/towny/' }
 
         String mavenUsername = System.getenv('mavenUsername') == null ? project.mavenUsername : System.getenv('mavenUsername');
         String mavenPassword = System.getenv('mavenPassword') == null ? project.mavenUsername : System.getenv('mavenPassword');
@@ -56,8 +55,6 @@ dependencies {
     compileOnly "org.spigotmc:v1_8_R3-Taco:latest"
     // CoreProtect
     compileOnly 'net.coreprotect:CoreProtect-6:latest'
-    // Towny
-    compileOnly 'com.palmergames.bukkit.towny:towny:0.98.0.0'
     // Plugin Hooks
 }
 


### PR DESCRIPTION
Towny deprecated getResident(String) in the TownyDataSource a while back and the last release saw the removal of this method.

This PR replaces it with what will be the final method to get a Resident from a player.

This may also be of use:

```
repositories {
    maven {
        name = 'glaremasters repo'
        url = 'https://repo.glaremasters.me/repository/towny/'
    }

dependencies {
    compileOnly 'com.palmergames.bukkit.towny:towny:0.98.0.0'
}
```
